### PR TITLE
Allow users to specify custom environment variable to override default API Key environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,16 @@ steps:
           server: "${MY_OCTOPUS_SERVER}"
 ```
 
+## Configuring
+
+### `OCTOPUS_CLI_SERVER`
+
+Your Octopus Server URL should be set to this environment variable, or you can use `server` in the steps of your pipeline instead.
+
+### `OCTOPUS_CLI_API_KEY`
+
+Your Octopus Server API key should be set to this environment variable, either in your pipeline’s environment variable settings or exposed in an [environment hook](https://buildkite.com/docs/pipelines/secrets#storing-secrets-in-environment-hooks). If you need different keys for different steps in your pipeline use `api_key` instead.
+
 ## 📥 Inputs
 
 **The following input is required:**
@@ -75,7 +85,7 @@ steps:
 
 | Name                     | Description                                                                                                                                                                                                                                                       |  Default   |
 | :----------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :--------: |
-| `api_key`                | The API key used to access Octopus Deploy. This value is required if credentials (`username` and `password`) are unspecified. `API-GUEST` may be used if the guest account is enabled. It is strongly recommended that this value retrieved from a GitHub secret. |            |
+| `api_key`                      | The environment variable that is configured with your Octopus Server API key used to access Octopus Deploy. Use this if you need to specify different keys for different steps in your pipeline.
 | `cancel_on_timeout`      | Cancel the deployment if `deployment_timeout` is exceeded (default: 10 minutes).                                                                                                                                                                                  |  `false`   |
 | `config_file`            | The path to a configuration file of default values with one `key=value` per line.                                                                                                                                                                                 |            |
 | `debug`                  | Enable debug logging.                                                                                                                                                                                                                                             |  `false`   |

--- a/hooks/command
+++ b/hooks/command
@@ -199,7 +199,7 @@ fi
 
 #api_key:
 if [[ -n "${BUILDKITE_PLUGIN_RUN_RUNBOOK_API_KEY:-}" ]]; then
-    args+=( "--apiKey" "${BUILDKITE_PLUGIN_RUN_RUNBOOK_API_KEY}" )
+    args+=( "--apiKey" "$(eval "echo \$${BUILDKITE_PLUGIN_RUN_RUNBOOK_API_KEY}")" )
     maskedArgs+=( "--apiKey" "SECRET" )
 fi
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -7,7 +7,7 @@ configuration:
   properties:
     api_key:
       type: string
-      description: 'The API key used to access Octopus Deploy. You must provide an API key or set the `OCTOPUS_CLI_API_KEY` environment variable. If the guest account is enabled, a key of API-GUEST may be used. It is strongly recommended that this value retrieved from an environment variable.'
+      description: 'Specifies the environment variable containing the Octopus Server API key'
     cancel_on_timeout:
       type: boolean
       default: false

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -85,3 +85,27 @@ load "$BATS_PATH/load.bash"
     unset BUILDKITE_PLUGIN_RUN_RUNBOOK_PROJECT
     unset BUILDKITE_PLUGIN_RUN_RUNBOOK_RUNBOOK
 }
+
+@test "Run runbook command overriding Server URL and API Key" {
+    export FAKE_API_KEY="API-123"
+    export BUILDKITE_PLUGIN_RUN_RUNBOOK_API_KEY="FAKE_API_KEY"
+    export BUILDKITE_PLUGIN_RUN_RUNBOOK_SERVER="https://octopus.example"
+    export BUILDKITE_PLUGIN_RUN_RUNBOOK_ENVIRONMENTS="Test"
+    export BUILDKITE_PLUGIN_RUN_RUNBOOK_PROJECT="Test project"
+    export BUILDKITE_PLUGIN_RUN_RUNBOOK_RUNBOOK="Test runbook"
+
+    stub octo "run-runbook --environment Test --project 'Test project' --runbook 'Test runbook' --server https://octopus.example --apiKey API-123 : echo octo command ran"
+
+    run $PWD/hooks/command
+
+    assert_output --partial "octo command ran"
+    assert_success
+
+    unstub octo
+    unset BUILDKITE_PLUGIN_RUN_RUNBOOK_ENVIRONMENTS
+    unset BUILDKITE_PLUGIN_RUN_RUNBOOK_PROJECT
+    unset BUILDKITE_PLUGIN_RUN_RUNBOOK_RUNBOOK
+    unset FAKE_API_KEY
+    unset BUILDKITE_PLUGIN_RUN_RUNBOOK_API_KEY
+    unset BUILDKITE_PLUGIN_RUN_RUNBOOK_SERVER
+}


### PR DESCRIPTION
> Plugins directly interpolate the API key into the `pipeline.yml`, which means there’s a risk of it being logged and passed around.

This PR is to address the above feedback from Buildkite about how we allowed users to enter their API keys directly in the yaml for our plugin